### PR TITLE
Create dist dir if it doesn't exist.

### DIFF
--- a/bin/version
+++ b/bin/version
@@ -13,6 +13,7 @@ export function getVersion() {
   return \`Neptune's Pride Agent v\${version_info.version} (\${date}\${caution}\${version_info.hash})\`;
 }
 EOF
+mkdir -p dist
 cat <<EOF > dist/manifest.json
 {
 		"name": "Neptune's Pride Agent$(grep '"version"' package.json | awk -F\. '{print $NF}' | sed -re 's/[1-9][0-9]*/  άλφα Edition/' | sed -re 's/(0-[0-9]*)?[^1-9][0-9]*//')


### PR DESCRIPTION
During the initial setup the dist dir doesn't yet exist and bin/version fails to write the manifest due to this. Create the dir so the first run just works.