### PR TITLE
Show all alliance research progress.

### DIFF
--- a/src/intel.ts
+++ b/src/intel.ts
@@ -4616,7 +4616,9 @@ function NeptunesPrideAgent() {
         } else {
           soFar = `[[bad:${soFar}]]`;
         }
-        line += `|${soFar} (L${tech.level})`;
+        line += `|${soFar}${player.researching === key ? "*" : ""} (L${
+          tech.level
+        })`;
       }
       output.push([line]);
     }

--- a/src/intel.ts
+++ b/src/intel.ts
@@ -4130,7 +4130,18 @@ function NeptunesPrideAgent() {
     terr: "Terra",
     weap: "Weapons",
   };
+  const xlateemoji: { [k: string]: string } = {
+    bank: "💰",
+    manu: "🔧",
+    prop: "🚀",
+    rese: "🧪",
+    scan: "📡",
+    terr: "🌎",
+    weap: "⚔️",
+  };
+
   let translateTech = (name: string) => xlate[name.substring(0, 4)];
+  let translateTechEmoji = (name: string) => xlateemoji[name.substring(0, 4)];
 
   const tradeCostForLevel = function (level: number) {
     if (NeptunesPride.gameVersion === "proteus") {
@@ -4546,6 +4557,37 @@ function NeptunesPrideAgent() {
       }
     }
     output.push("--- Alliance Research Progress ---");
+    output.push("--- All Alliance Research ---");
+    output.push(":--|:--|--:|--:|--:|--");
+    const techs = [
+      "scanning",
+      "propulsion",
+      "terraforming",
+      "research",
+      "weapons",
+      "banking",
+      "manufacturing",
+    ];
+    output.push(
+      `Empire|${techs.map((key) => translateTechEmoji(key)).join("|")}`,
+    );
+    for (let pii = 0; pii < playerIndexes.length; ++pii) {
+      const pi = playerIndexes[pii];
+      const p = players[pi];
+      const apiKey = await store.get(apiKeys[pii]);
+      const scan = await getUserScanData(apiKey);
+      if (scan) {
+        const player = scan.players[pi];
+        let line = `[[${pi}]]`;
+        for (const key of techs) {
+          const tech = player.tech[key];
+          const soFar = tech.research;
+          line += `|${soFar} (L${tech.level})`;
+        }
+        output.push([line]);
+      }
+    }
+    output.push("--- All Alliance Research ---");
     prepReport("research", output);
   };
   defineHotkey(

--- a/src/intel.ts
+++ b/src/intel.ts
@@ -4558,7 +4558,6 @@ function NeptunesPrideAgent() {
     }
     output.push("--- Alliance Research Progress ---");
     output.push("--- All Alliance Research ---");
-    output.push(":--|:--|--:|--:|--:|--");
     const techs = [
       "scanning",
       "propulsion",
@@ -4568,6 +4567,7 @@ function NeptunesPrideAgent() {
       "banking",
       "manufacturing",
     ];
+    output.push(`:--|${techs.map(() => "--:").join("|")}`);
     output.push(
       `Empire|${techs.map((key) => translateTechEmoji(key)).join("|")}`,
     );


### PR DESCRIPTION
Updates the alliance research screen to show progress for all research areas regardless of the one currently being researched. This is useful for coordinating research to quickly figure out who is closest to the next level.