### PR TITLE
Simplify all alliance research report.

### DIFF
--- a/src/intel.ts
+++ b/src/intel.ts
@@ -4623,13 +4623,8 @@ function NeptunesPrideAgent() {
       }
     }
     output.push("--- Alliance Research Progress ---");
-    output.push("--- All Alliance Research ---");
     const player = NeptunesPride.universe.player;
     const techs = Object.keys(player.tech);
-    output.push(`:--|${techs.map(() => "--:").join("|")}`);
-    output.push(
-      `Empire|${techs.map((key) => translateTechEmoji(key)).join("|")}`,
-    );
     type BestProgress = {
       [key: string]: {
         level: number;
@@ -4661,6 +4656,15 @@ function NeptunesPrideAgent() {
         }
       }
     }
+    output.push("--- All Alliance Research ---");
+    output.push(`:--|${techs.map(() => "--:").join("|")}`);
+    output.push(
+      `Empire|${techs
+        .map(
+          (key) => `<sub>L${best[key].level}</sub> ${translateTechEmoji(key)}`,
+        )
+        .join("|")}`,
+    );
     for (let pii = 0; pii < playerIndexes.length; ++pii) {
       const pi = playerIndexes[pii];
       const p = players[pi];
@@ -4679,9 +4683,19 @@ function NeptunesPrideAgent() {
         } else {
           soFar = `[[bad:${soFar}]]`;
         }
-        line += `|${soFar}${player.researching === key ? "*" : ""} (L${
-          tech.level
-        })`;
+        line += `| ${soFar}`;
+        const researchPriority =
+          player.researching === key
+            ? 1
+            : player.researching_next === key
+            ? 2
+            : null;
+        if (researchPriority !== null) {
+          line += `<sub style="font-size: 50%">${researchPriority}</sub>`;
+        }
+        if (tech.level < best[key].level) {
+          line += `<div><sub>(L${tech.level})</sub></div>`;
+        }
       }
       output.push([line]);
     }

--- a/src/intel.ts
+++ b/src/intel.ts
@@ -4684,14 +4684,17 @@ function NeptunesPrideAgent() {
           soFar = `[[bad:${soFar}]]`;
         }
         line += `| ${soFar}`;
-        const researchPriority =
-          player.researching === key
-            ? 1
-            : player.researching_next === key
-            ? 2
-            : null;
-        if (researchPriority !== null) {
-          line += `<sub style="font-size: 50%">${researchPriority}</sub>`;
+        let researchPriority = [];
+        if (player.researching === key) {
+          researchPriority.push(1);
+        }
+        if (player.researching_next === key) {
+          researchPriority.push(2);
+        }
+        if (researchPriority.length > 0) {
+          line += `<sub style="font-size: 50%">${researchPriority.join(
+            ",",
+          )}</sub>`;
         }
         if (tech.level < best[key].level) {
           line += `<div><sub>(L${tech.level})</sub></div>`;


### PR DESCRIPTION
* Show best tech level in table headers.
* Only show empire level if it's not at the best level.
* Show first and second research priority.