### PR TITLE
Clarify documentation for My WS-1 handicap

### DIFF
--- a/tests/playwright/001-battle-hud/001-battle-hud.spec.ts
+++ b/tests/playwright/001-battle-hud/001-battle-hud.spec.ts
@@ -400,14 +400,14 @@ test("documents the battle HUD controls and timebases", async ({
     ],
     documentation: {
       summary:
-        "Press **,** again to continue past the regular calculation into `My WS-1`. A negative local weapons adjustment grants the other side of the battle the weapons advantage for the local projection.",
+        "Press **,** again to continue past the regular calculation into `My WS-1`. This \"My WS-1\" setting credits your side (the side NPA is modeling) with an extra weapons level (+1), granting you the advantage. Although the label shows -1, it represents a +1 weapons advantage for your side.",
       howToUse: [
         "Start from the regular weapons calculation.",
         "Press **,** one more time to display `My WS-1`.",
       ],
       expectedResult: [
         "The footer overlay changes to show `My WS-1`.",
-        "The survivor estimate reflects the opposite weapons assumption, effectively granting your opponent the advantage.",
+        "The survivor estimate reflects the extra weapons level, granting your side the weapons advantage.",
       ],
       caveats: [
         "These adjustments follow the same perspective rule: the label is relative to the side NPA is currently modeling as 'you' in the planning view.",

--- a/tests/playwright/001-battle-hud/001-battle-hud.spec.ts
+++ b/tests/playwright/001-battle-hud/001-battle-hud.spec.ts
@@ -354,7 +354,7 @@ test("documents the battle HUD controls and timebases", async ({
     ],
     documentation: {
       summary:
-        "Press **,** to remove weapons adjustments and return the battle HUD to the regular calculation. This gives you a visual checkpoint for the baseline survivor estimate before trying the opposite assumption.",
+        "Press **,** to remove weapons adjustments and return the battle HUD to the regular calculation. This gives you a visual checkpoint for the baseline survivor estimate before modeling your own weapons advantage.",
       howToUse: [
         "Start from the `Enemy WS+1` view.",
         "Press **,** once to step the weapons adjustment back to zero.",
@@ -368,7 +368,7 @@ test("documents the battle HUD controls and timebases", async ({
 
   await frameAndAssertBattleMap(appPage);
   await helper.step("apply-my-ws-minus-one", {
-    description: "Model the opposite weapons advantage with My WS-1",
+    description: "Model a weapons advantage with My WS-1",
     verifications: [
       {
         spec: "Pressing , again displays My WS-1 and changes the footer calculation from the regular baseline",

--- a/tests/playwright/001-battle-hud/DOCS.md
+++ b/tests/playwright/001-battle-hud/DOCS.md
@@ -85,7 +85,7 @@ You can manually adjust the weapons technology assumptions for a fight to see if
 
 ## Return to the regular weapons calculation
 
-Press **,** to remove weapons adjustments and return the battle HUD to the regular calculation. This gives you a visual checkpoint for the baseline survivor estimate before trying the opposite assumption.
+Press **,** to remove weapons adjustments and return the battle HUD to the regular calculation. This gives you a visual checkpoint for the baseline survivor estimate before modeling your own weapons advantage.
 
 ![Return to the regular weapons calculation](./screenshots/005-clear-combat-handicap.png)
 

--- a/tests/playwright/001-battle-hud/DOCS.md
+++ b/tests/playwright/001-battle-hud/DOCS.md
@@ -97,11 +97,11 @@ Press **,** to remove weapons adjustments and return the battle HUD to the regul
 - The footer no longer shows an adjustment, returning you to the baseline projection.
 - The selected synthetic fleet and route toward its destination remain visible for easy comparison.
 
-## Model the opposite weapons advantage with My WS-1
+## Model a weapons advantage with My WS-1
 
-Press **,** again to continue past the regular calculation into `My WS-1`. A negative local weapons adjustment grants the other side of the battle the weapons advantage for the local projection.
+Press **,** again to continue past the regular calculation into `My WS-1`. This "My WS-1" setting credits your side (the side NPA is modeling) with an extra weapons level (+1), granting you the advantage. Although the label shows -1, it represents a +1 weapons advantage for your side.
 
-![Model the opposite weapons advantage with My WS-1](./screenshots/006-apply-my-ws-minus-one.png)
+![Model a weapons advantage with My WS-1](./screenshots/006-apply-my-ws-minus-one.png)
 
 ### How to use it
 - Start from the regular weapons calculation.
@@ -109,7 +109,7 @@ Press **,** again to continue past the regular calculation into `My WS-1`. A neg
 
 ### What to expect
 - The footer overlay changes to show `My WS-1`.
-- The survivor estimate reflects the opposite weapons assumption, effectively granting your opponent the advantage.
+- The survivor estimate reflects the extra weapons level, granting your side the weapons advantage.
 
 ### Caveats
 - These adjustments follow the same perspective rule: the label is relative to the side NPA is currently modeling as 'you' in the planning view.

--- a/tests/playwright/001-battle-hud/README.md
+++ b/tests/playwright/001-battle-hud/README.md
@@ -61,9 +61,9 @@ Companion user documentation: [DOCS.md](./DOCS.md)
 - [x] The fake enemy fleet and battle route remain selected after clearing the handicap
 - [x] The regular-calculation screenshot keeps Hot Sham, the selected fleet route, and the battle HUD footer in frame
 
-## Model the opposite weapons advantage with My WS-1
+## Model a weapons advantage with My WS-1
 
-![Model the opposite weapons advantage with My WS-1](./screenshots/006-apply-my-ws-minus-one.png)
+![Model a weapons advantage with My WS-1](./screenshots/006-apply-my-ws-minus-one.png)
 
 ### Verifications
 - [x] Pressing , again displays My WS-1 and changes the footer calculation from the regular baseline


### PR DESCRIPTION
This PR clarifies the documentation for the My WS-1 combat calculation handicap in the battle hud tests. It explicitly states that My WS-1 credits the modeled side with a +1 weapons advantage, even though the label shows -1.

Changes:
- Updated tests/playwright/001-battle-hud/DOCS.md
- Updated tests/playwright/001-battle-hud/README.md
- Updated tests/playwright/001-battle-hud/001-battle-hud.spec.ts

Closes #59